### PR TITLE
Fix multi-threading for OSX

### DIFF
--- a/Interlace/lib/threader.py
+++ b/Interlace/lib/threader.py
@@ -1,4 +1,5 @@
 import threading
+import subprocess
 import os
 
 
@@ -20,7 +21,7 @@ class Worker(object):
 
     @staticmethod
     def run_task(task):
-        os.system(task)
+        subprocess.call(task, shell=true)
 
 
 class Pool(object):


### PR DESCRIPTION
Issue was with how OSX handles os.system( ) calls. (I believe it's like they were trying to share the same shell, so they would therefore naturally block future calls making it synchronous)
Switched to subprocess.call( ) and allowing each worker to spawn their own instance of a shell.