### PR TITLE
Add _block:_ and _blocker_ features as per #52

### DIFF
--- a/Interlace/interlace.py
+++ b/Interlace/interlace.py
@@ -6,12 +6,11 @@ from Interlace.lib.threader import Pool
 
 
 def build_queue(arguments, output):
-    queue = list()
-    for command in InputHelper.process_commands(arguments):
-        output.terminal(Level.THREAD, command, "Added to Queue")
-        queue.append(command)
+    queue = InputHelper.process_commands(arguments)
+    for command_list in queue:
+        for command in command_list:
+            output.terminal(Level.THREAD, command, "Added to Queue")
     return queue
-
 
 def main():
     parser = InputParser()

--- a/Interlace/lib/core/input.py
+++ b/Interlace/lib/core/input.py
@@ -40,7 +40,7 @@ class InputHelper(object):
                     logging_block = False
                     commands_list.append([])
                 else:
-                    print("Warning: _block:%s_ instruction wasn't closed" % block_name)
+                    print("Warning: _block:%s_ instruction wasn't closed" % logging_block)
             elif command == "_blocker_":
                 commands_list.append([])
             elif logging_block:

--- a/Interlace/lib/core/input.py
+++ b/Interlace/lib/core/input.py
@@ -103,8 +103,9 @@ class InputHelper(object):
         output = OutputHelper(arguments)
 
         # removing the trailing slash if any
-        if arguments.output[-1] == "/":
-            arguments.output = arguments.output[:-1]
+        if arguments.output:
+            if arguments.output[-1] == "/":
+                arguments.output = arguments.output[:-1]
 
         if arguments.port:
             if "," in arguments.port:

--- a/Interlace/lib/core/input.py
+++ b/Interlace/lib/core/input.py
@@ -26,7 +26,7 @@ class InputHelper(object):
 
     @staticmethod
     def _process_blockers(commands):
-        commands_list = [[]]
+        command_lists = [[]]
         logging_block = False
 
         for command in commands:
@@ -38,19 +38,19 @@ class InputHelper(object):
                 elif logging_block == block_name:
                     # Stop logging
                     logging_block = False
-                    commands_list.append([])
+                    command_lists.append([])
                 else:
                     print("Warning: _block:%s_ instruction wasn't closed" % logging_block)
             elif command == "_blocker_":
-                commands_list.append([])
+                command_lists.append([])
             elif logging_block:
                 # Add command as its own array (since blocking is enabled)
-                commands_list.append([command])
+                command_lists.append([command])
             else:
                 # Add command onto last array (since blocking is disabled)
-                commands_list[-1].append(command)
+                command_lists[-1].append(command)
 
-        return commands_list
+        return command_lists
 
     @staticmethod
     def _get_ips_from_range(ip_range):

--- a/Interlace/lib/threader.py
+++ b/Interlace/lib/threader.py
@@ -62,7 +62,7 @@ class Pool(object):
         # sequentially run per command_list
         for command_list in self.queue:
             workers = [Worker(command_list, self.timeout, self.output, self.tqdm) for w in range(self.max_workers)]
-            threads = []
+            threads = list()
 
             # run
             for worker in workers:

--- a/Interlace/lib/threader.py
+++ b/Interlace/lib/threader.py
@@ -59,20 +59,20 @@ class Pool(object):
             self.tqdm = True
 
     def run(self):
+        # sequentially run per command_list
+        for command_list in self.queue:
+            workers = [Worker(command_list, self.timeout, self.output, self.tqdm) for w in range(self.max_workers)]
+            threads = []
 
-        workers = [Worker(self.queue, self.timeout, self.output, self.tqdm) for w in range(self.max_workers)]
-        threads = []
+            # run
+            for worker in workers:
+                thread = threading.Thread(target=worker)
+                thread.start()
+                threads.append(thread)
 
-
-        # run
-        for worker in workers:
-            thread = threading.Thread(target=worker)
-            thread.start()
-            threads.append(thread)
-
-        # wait until all workers have completed their tasks
-        for thread in threads:
-            thread.join()
+            # wait until all workers have completed their tasks
+            for thread in threads:
+                thread.join()
 
 # test harness
 if __name__ == "__main__":


### PR DESCRIPTION
I'm well aware that a PR already exists for this. However, I'd like to bring to light a different approach using arrays: splitting commands into arrays, and treating every array as a separate sequence of threads. In this solution, a `_block:_` instruction essentially turns each command into its own array.