### PR TITLE
Fix issue of breaking process when a child process of subprocess closes stdout pipe

### DIFF
--- a/Interlace/lib/threader.py
+++ b/Interlace/lib/threader.py
@@ -48,8 +48,10 @@ class Task(object):
 
     def _run_task(self, t=False):
         if t:
-            s = subprocess.Popen(self.task, shell=True, stdout=subprocess.PIPE)
-            out = s.stdout.readline().decode("utf-8")
+            s = subprocess.Popen(self.task, shell=True,
+                                 stdout=subprocess.PIPE,
+                                 encoding="utf-8")
+            out, _ = s.communicate()
             if out != "":
                 t.write(out)
         else:


### PR DESCRIPTION
This PR fixes the issue of threader immediately returning when `subprocess.Popen()` releases the block on reading stdout. This happens in some processes where child processes spawned by the subprocesses themselves can close stdout pipe.

Fixes: #95 