### PR TITLE
Update check_positive method to handle ValueError exception.

### DIFF
--- a/Interlace/lib/core/input.py
+++ b/Interlace/lib/core/input.py
@@ -19,9 +19,12 @@ class InputHelper(object):
 
     @staticmethod
     def check_positive(parser, arg):
-        ivalue = int(arg)
-        if ivalue <= 0:
-            raise parser.ArgumentTypeError("%s is not a valid positive integer!" % arg)
+        try:
+            ivalue = int(arg)
+            if ivalue <= 0:
+                raise parser.ArgumentTypeError("%s is not a valid positive integer!" % arg)
+        except ValueError as e:
+            raise parser.ArgumentValueError("%s is not a a number!" % arg)
 
         return arg
 


### PR DESCRIPTION
I saw that, despite you're testing if the thread argument is positive, you're not testing if it's a number, so "ivalue = int(arg)" can cause an exception if I pass an argument like "--thread abc". I didn't have much time to chack if you test this somewhere else, but I think you don't. Thanks for the opportunity! I hope I can help.