### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorclass==2.2.0
-netaddr==0.7.19
+netaddr==0.7.20
 tqdm==4.36.1


### PR DESCRIPTION
Changed netaddr from 0.7.19 to 0.7.20.

This resolves an issue with Interlace throwing a warning with netaddr.