### PR TITLE
encoding bug fixed at setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ def dependencies(imported_file):
         return file.read().splitlines()
 
 
-with open("README.md") as file:
+with open("README.md", encoding="utf-8") as file:
     num_installed = True
     try:
         import numpy


### PR DESCRIPTION
I discovered the following bug in the 'setup.py' script on some operating systems: 

```UnicodeDecodeError: 'ascii' codec can't decode byte 0xe2 in position 8400: ordinal not in range(128).``` 

In this case Python cannot determine the correct encoding. Therefore I added the encoding 'utf-8' in the installation script in a hardcoded manner.  If you habe any questions regarding this bug feel free to ask me. 