### PR TITLE
Removed some print statements

### DIFF
--- a/Interlace/interlace.py
+++ b/Interlace/interlace.py
@@ -17,9 +17,6 @@ def task_queue_generator_func(arguments, output, repeat):
         for task in tasks_iterator:
             output.terminal(Level.THREAD, task.name(), "Added to Queue")
             yield task
-    print('Generated {} commands in total'.format(tasks_count))
-    print('Repeat set to {}'.format(repeat))
-
 
 def main():
     parser = InputParser()

--- a/Interlace/lib/core/input.py
+++ b/Interlace/lib/core/input.py
@@ -212,7 +212,6 @@ class InputHelper(object):
                     
                     for i in target_spec:
                         ips_list.append(str(i))
-                    print(f"updating: {target_spec}")
             return (str_targets, set(ips_list))
 
         str_targets, ipset_targets = parse_and_group_target_specs(


### PR DESCRIPTION
https://github.com/codingo/Interlace/issues/152

Maybe instead of removing the print statements from Interlace.py we can only execute them when `--silent` isnt used. As for input.py, what the the thought process behind ` print(f"updating: {target_spec}")`?